### PR TITLE
Changed title displayed in tab to 'For Me' instead of 'Simple React App'

### DIFF
--- a/react-app/public/index.html
+++ b/react-app/public/index.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta charset="utf-8" />
-    <title>Simple React App</title>
+    <title>ForMe</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Acme&family=Lato&display=swap" rel="stylesheet">
@@ -13,4 +13,3 @@
     <div id="root"></div>
   </body>
 </html>
-


### PR DESCRIPTION
Changed the title in the browser tab to display "ForMe" instead of "Simple React App."
No other changes were made.