### PR TITLE
Fix alignment of form desscription on rendered form page.

### DIFF
--- a/react-app/src/components/Forms/Forms.css
+++ b/react-app/src/components/Forms/Forms.css
@@ -302,7 +302,7 @@ form.shared-form {
 	width: 400px;
 }
 
-.form-title {
+.form-title, .form-description {
 	margin-left: 320px;
 }
 

--- a/react-app/src/components/Forms/SharedForm.js
+++ b/react-app/src/components/Forms/SharedForm.js
@@ -10,7 +10,7 @@ function SharedForm() {
     const form = useSelector(state => state.forms)
     const { formId } = useParams()
 
-    let fieldsArray = form[formId]?.fields  
+    let fieldsArray = form[formId]?.fields
 
     useEffect(() => {
         dispatch(getSharedForm(formId))
@@ -20,14 +20,14 @@ function SharedForm() {
         <div>
             <form classNames="shared-form">
                 <h2 className="form-title">{form[formId]?.title}</h2>
-                <p>{form[formId]?.description}</p>
+                <p className='form-description'>{form[formId]?.description}</p>
                 {
                     fieldsArray?.map(field => <FormField field={field} />)
                 }
                 <Link to="/forms"><button className="forms-return">Back To Forms</button></Link>
             </form>
         </div>
- 
+
     )
 }
 


### PR DESCRIPTION
Moved alignment of form description to look better with form title on the rendered form page. (was all the way to the left).
No other changes were made.